### PR TITLE
Update python/intro.md and add sphinx-exercise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ Icon?
 
 # Built Jupyter-book documentation
 docs/book/_build
+
+# Backup docs
+pdfs/*
+

--- a/docs/book/UN-OG-Training_references.bib
+++ b/docs/book/UN-OG-Training_references.bib
@@ -9,19 +9,6 @@
   pages = {159-178},
 }
 
-@ARTICLE{HurstEtAl:2014,
-title = {Are Household Surveys Like Tax Forms? Evidence from Income Underreporting of the Self-Employed},
-author = {Hurst, Erik and Li, Geng and Pugsley, Benjamin},
-year = {2014},
-journal = {The Review of Economics and Statistics},
-volume = {96},
-number = {1},
-pages = {19-33},
-abstract = {A large literature shows that the self-employed underreport their income to tax authorities. In this paper, we quantify the extent to which the self-employed also systematically underreport their income in U.S. household surveys. We use the Engel curve describing the relationship between income and expenditures of wage and salary workers to infer the actual income, and thus the reporting gap, of the self-employed based on their reported expenditures. On average, the self-employed underreport their income by about 25%. We show that failing to account for such income underreporting leads to biased conclusions in a variety of settings. © No rights reserved. This work was authored as part of the Contributor's official duties as an Employee of the United States Government and is therefore a work of the United States Government. In accordance with 17 U.S.C. 105, no copyright protection is available for such works under U.S. law.},
-keywords = {household surveys; self-employment; income; taxes},
-url = {https://EconPapers.repec.org/RePEc:tpr:restat:v:96:y:2014:i:1:p:19-33}
-}
-
 @INCOLLECTION{AuerbachKotlikoff:1983a,
   AUTHOR = {Alan J. Auerbach and Laurence J. Kotlikoff},
   TITLE = {National Savings, Economic Welfare, and the Structure of Taxation},
@@ -117,6 +104,15 @@ url = {https://EconPapers.repec.org/RePEc:tpr:restat:v:96:y:2014:i:1:p:19-33}
   pages = {142-160},
 }
 
+@TECHREPORT{BYUACME_PythonIntro,
+  AUTHOR = {BYU ACME},
+  TITLE = {Introduction to Python},
+  INSTITUTION = {Brigham Young University Applied and Computational Mathematics Emphasis},
+  YEAR = {2021},
+  type = {Open access lab},
+  url = {https://acme.byu.edu/00000181-448a-d778-a18f-dfcae22f0001/intro-to-python},
+}
+
 @ARTICLE{CarrollEtAl:2017,
   AUTHOR = {Christopher Carroll and Jiri Slacalek and Kiichi Tokuoka and Matthew N. White},
   TITLE = {The Distribution of Wealth and the Marginal Propensity to Consume},
@@ -204,6 +200,24 @@ url = {https://EconPapers.repec.org/RePEc:tpr:restat:v:96:y:2014:i:1:p:19-33}
   pages = {65-66},
 }
 
+@ARTICLE{GitWiki2020,
+  AUTHOR = {{Wikipedia Contributors}},
+  TITLE = {"{G}it"},
+  JOURNAL = {{W}ikipedia{,} The Free Encyclopedia},
+  YEAR = {2020},
+  note = {[Online; accessed 19-August-2020]},
+  url = {https://en.wikipedia.org/wiki/Git},
+}
+
+@ARTICLE{GitIDE2020,
+  AUTHOR = {{Wikipedia Contributors}},
+  TITLE = {"{I}ntegrated development environment"},
+  JOURNAL = {{W}ikipedia{,} The Free Encyclopedia},
+  YEAR = {2020},
+  note = {[Online; accessed 3-August-2020]},
+  url = {https://en.wikipedia.org/wiki/Integrated_development_environment},
+}
+
 @Article{GouveiaStrauss:1994,
   author={Miguel Gouveia and Robert P. Strauss},
   title={Effective Federal Individual Tax Functions: An Exploratory Empirical Analysis},
@@ -213,6 +227,17 @@ url = {https://EconPapers.repec.org/RePEc:tpr:restat:v:96:y:2014:i:1:p:19-33}
   number={2},
   pages={317-39},
   month={June},
+}
+
+@ARTICLE{HurstEtAl:2014,
+  title = {Are Household Surveys Like Tax Forms? Evidence from Income Underreporting of the Self-Employed},
+  author = {Hurst, Erik and Li, Geng and Pugsley, Benjamin},
+  year = {2014},
+  journal = {The Review of Economics and Statistics},
+  volume = {96},
+  number = {1},
+  pages = {19-33},
+  url = {https://EconPapers.repec.org/RePEc:tpr:restat:v:96:y:2014:i:1:p:19-33}
 }
 
 @TECHREPORT{MoorePecoraro:2021,

--- a/docs/book/_config.yml
+++ b/docs/book/_config.yml
@@ -89,7 +89,7 @@ sphinx:
 sphinx:
   extra_extensions: ['sphinx.ext.autodoc', 'sphinx.ext.mathjax',
                      'sphinx.ext.viewcode', 'sphinx.ext.napoleon',
-                     'alabaster']  # A list of extra extensions to load by Sphinx.
+                     'alabaster', 'sphinx_exercise']  # A list of extra extensions to load by Sphinx.
   config:  # key-value pairs to directly over-ride the Sphinx configuration
     bibtex_reference_style: author_year
     mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
@@ -103,3 +103,4 @@ sphinx:
     - "sphinx.ext.viewcode"
     - "sphinx.ext.napoleon"
     - "sphinx.ext.mathjax"
+    - "sphinx_exercise"

--- a/docs/book/_toc.yml
+++ b/docs/book/_toc.yml
@@ -24,6 +24,7 @@ parts:
     - file: OG/Calibration
   - caption: Appendix
     chapters:
+    - file: appendix/glossary
     - file: appendix/intro
   - caption: References
     chapters:

--- a/docs/book/appendix/glossary.md
+++ b/docs/book/appendix/glossary.md
@@ -1,0 +1,112 @@
+(chap_glossary)=
+# Glossary
+
+```{glossary}
+application programming interface (API)
+  An application programming interface or API is the medium, method, and rules through which a user interacts with software. The API includes a medium which can be a {term}`command line interface` on a specific {term}`local` terminal or a {term}`graphical user interface`. The API also defines the commands through which a user interacts with the software.
+
+benevolent dictator
+  TODO: Make *benevolent dictator* entry...
+
+Bitbucket
+  *Bitbucket* or [*Bitbucket.org*](https://bitbucket.org/) is a {term}`cloud` {term}`source code management service` platform designed to enable scalable, efficient, and secure version controlled collaboration by linking {term}`local` {term}`Git` version controlled software development by developers.
+
+Bitkeeper
+  TODO: Put Bitkeeper definition here...
+
+Box, Inc.
+  TODO: Box Inc. definition... University file sharing company...
+
+branch
+  TODO: define branch
+
+centralized version control system
+  A centralized version control system or CVCS is an approach to version control in which all the files in a {term}`repository` as well as the change history (content and timing) are located on a central {term}`remote` server. User's check out versions of files from the repository and check them back in, creating new change history on the central server.
+
+clone
+  Clone can be a verb or a noun in the context of {term}`Git` software. A clone is a {term}`local` copy of a {term}`remote` {term}`repository` with its entire Git {term}`distributed version control system` history. To *clone* a repository is to use the `git clone [repo path]` command to copy a remote repository to your local machine with the accompanying Git version control history.
+
+cloud
+  Cloud can be a descriptor or a noun. As a descriptor, cloud refers to computational resources, such as servers, that are accessed remotely via the internet. As a noun, remote computational resources and storage can be referred to generically as "the cloud".
+
+command line interface
+  TODO: A *command line interface* or CLI...
+
+commit
+  TODO: *Commit* can be a verb or a noun. Define commit...
+
+continuous integration
+  Continuous integration or continuous integration unit testing is...
+
+distributed version control system
+  A *distributed version control system* or DVCS is {term}`version control system` software on any computer, {term}`local` or {term}`remote`, that tracks the entire history of changes to a {term}`repository` and coordinates and organizes collaboration among multiple users. It is distributed in the sense that multiple {term}`clone`s of a single {term}`remote` repository have the same full history of that repository.
+
+Dropbox
+  TODO: define Dropbox
+
+fork
+  TODO: define fork
+
+Git
+  *Git* is {term}`open source` {term}`version control system` software with capability designed to also operate as {term}`distributed version control system` (DVCS) software that resides on your local computer and tracks changes and the history of changes to all the files in a directory or {term}`repository`. See the Git website [https://git-scm.com/](https://git-scm.com/) and the [Git Wikipedia entry](https://en.wikipedia.org/wiki/Git) {cite}`GitWiki2020` for more information.
+
+GitHub
+  *GitHub* or [*GitHub.com*](https://github.com/) is a {term}`cloud` {term}`source code management service` platform designed to enable scalable, efficient, and secure version controlled collaboration by linking {term}`local` {term}`Git` version controlled software development by users. *GitHub*'s main business footprint is hosting a collection of millions of version controlled code repositories. In addition to being a platform for {term}`distributed version control system` (DVCS), *GitHub*'s primary features include code review, project management, {term}`continuous integration` {term}`unit testing`, {term}`GitHub actions`, and associated web page (GitHub pages) and documentation hosting and deployment.
+
+GitHub actions
+  GitHub actions
+
+GitLab
+  TODO: define *GitLab*...
+
+Google Docs
+  TODO: define Google Docs
+
+Google Drive
+  TODO: define Google Drive
+
+graphical user interface
+  A graphical user interface or GUI...
+
+integrated development environment
+  Integrated development environment or IDE is a software application that comsolidates many of the functions of software development under one program. IDE's often include a code editor, object memory and identification, debugger, and build automation tools. (See [IDE Wikipedia entry](https://en.wikipedia.org/wiki/Integrated_development_environment) {cite}`GitIDE2020`.)
+
+Linux
+  TODO: write Linux description...
+
+local
+  *Local* is a descriptor that refers to files that reside or operations that are performed on a user's machine to which he or she has direct access without using the internet.
+
+local version control system
+  A *local version control system* or LVCS is the simplest and most common approach to VCS. LVCS stores all the changes to the files in a {term}`repository` locally on the user's machine as a series of changes or deltas in the files. This is the approach taken by Apple's Time Machine backup software as most software that includes an "undo" function.
+
+merge
+  TODO: create *merge* entry...
+
+OG-Core
+  *`OG-Core`* is an open source large scale overlapping generations macroeconomic model of fiscal policy. This model is general and is a dependency of country calibrations that use `OG-Core`, such as `OG-USA`.
+
+open source
+  *Open source* is a descriptor that is usually applied to software or computer code projects, but can also be applied to any project based upon or represented by digital files. An open source project is one in which the source code is freely available to be downloaded and used and in which collaboration, improvements, and changes to the code are encouraged. The free download and use (outward direction) aspect of *open source* is often emphasized. But the collaboration and improvement contribution (inward direction) aspect is at least as important. {term}`Git` and {term}`GitHub` have enabled efficient and scalable collaboration to a degree not seen in other collaborative workflows.
+
+pull request
+  TODO: define *pull request*...
+
+remote
+  *Remote* is a descriptor that refers to files that reside or operations that are carried out on a server to which a user has access using the internet.
+
+repository
+  A *repository* or "repo" is a directory containing files that are tracked by a version control system. A local repository resides on a local machine. A remote repository resides in the cloud.
+
+source code management service
+  A *source code management service* is a {term}`cloud` platform that hosts computer code files and provides either {term}`centralized version control system` (CVCS) or {term}`distributed version control system`. As the central hub of either CVCS or DVCS, the source code management service provides the platform and rules for distributed code collaboration. Leading examples are {term}`GitHub` and {term}`Bitbucket`.
+
+unit testing
+  Unit testing is...
+
+version control system
+  *Version control system* or version control software or VCS is software that records changes to a set of files, including the order in which the changes were made and the content of those changes, in such a way that previous versions can be recalled or restored.
+
+Visual Studio Code (VS Code)
+  *Visual Studio Code* or *VS Code* is an open source text editor maintained by Microsoft.
+```

--- a/docs/book/python/intro.md
+++ b/docs/book/python/intro.md
@@ -82,7 +82,7 @@ All of these will be included as part of your installation of Anaconda.  Anacond
 8. [Unit testing in Python](UnitTesting.md)
 
 
-(SecPythonIntroFootnotes)=
-## Footnotes
+<!-- (SecPythonIntroFootnotes)=
+## Footnotes -->
 
 <!-- [^citation_note]: See {cite}`AuerbachEtAl:1981,AuerbachEtAl:1983`, {cite}`AuerbachKotlikoff:1983a,AuerbachKotlikoff:1983b,AuerbachKotlikoff:1983c`, and {cite}`AuerbachKotlikoff:1985`. -->

--- a/docs/book/python/intro.md
+++ b/docs/book/python/intro.md
@@ -1,27 +1,35 @@
 (Chap_PythonIntro)=
-
-
 # Introduction to Python
 
-The `OG-Core` model, as well as the country-specific calibration packages, are written in the Python programming language.  These training materials will provide you with sufficient background with Python and some of its most-used packages for data science that you will be able to understand and contribute to the source code underlying `OG-Core` and the calibration packages. We assume some basic background with mathematics, economics, and programming, but we do not assume any prior knowledge of Python.
+The `OG-Core` model, as well as the country-specific calibration packages, are written in the Python programming language. These training materials will provide you with sufficient background with Python and some of its most-used packages for data science that you will be able to understand and contribute to the source code underlying `OG-Core` and the calibration packages. We assume some basic background with mathematics, economics, and programming, but we do not assume any prior knowledge of Python.
 
-As we walk you through the basics of Python, we will leverage some excellent open source materials put together by [QuantEcon](https://quantecon.org/) and the [Applied and Computational Mathematics Emphasis at BYU](https://acme.byu.edu/).  And while we will point you to their tutorials, we've customized all our excercises to be relevant to the `OG-Core` model and the calibration packages.
+As we walk you through the basics of Python, we will leverage some excellent open source materials put together by [QuantEcon](https://quantecon.org/) and the [Applied and Computational Mathematics Emphasis at BYU (BYU ACME)](https://acme.byu.edu/). And while we will point you to their tutorials, we have customized all our excercises to be relevant to the `OG-Core` model and the calibration packages.
 
-# Overview of Python
-Python is an object-oriented programming (OOP) programming language... it's an interpreted language... it's a general purpose programming language... it's an open source language....
+## Overview of Python
+The Python.org site has documentation essays, one of which is entitled "[What is Python? Executive Summary](https://www.python.org/doc/essays/blurb/)". The first paragraph contains the following description.
 
-Python has some built in functionality with the standard library, but most of the functionality comes from packages that are developed by the open source community.  The most important packages for data science are: NumPy, SciPy, Pandas, and Matplotlib.  We will introduce each of these packages as we go through the training materials as they are used heavily in `OG-Core` and the calibration packages.
+> Python is an interpreted, object-oriented, high-level programming language with dynamic semantics. Its high-level built in data structures, combined with dynamic typing and dynamic binding, make it very attractive for Rapid Application Development, as well as for use as a scripting or glue language to connect existing components together. Python's simple, easy to learn syntax emphasizes readability and therefore reduces the cost of program maintenance. Python supports modules and packages, which encourages program modularity and code reuse. The Python interpreter and the extensive standard library are available in source or binary form without charge for all major platforms, and can be freely distributed.
 
-# Installing Python
-We recommend that you download the Anaconda distribution of Python provided by [Anaconda](https://anaconda.org). We also recommend the most recent stable version of Python, which is currently Python 3.10. This can be done from the [Anaconda download page](https://www.anaconda.com/downloads) for Windows, Mac OSX, and Linux machines. The code we will be writing uses common Python libraries such as `NumPy`, `SciPy`, `pickle`, `os`, `matplotlib`, and `time`, which are all included in the Anaconda distribution.  If you are using a different distribution of Python, you may need to install these packages separately.
+In addition to the description above, Python is an open source programming language that is freely available and customizable (see https://www.python.org/downloads/source/).
 
-# Working with Python
+Python has some built in functionality with the standard library, but most of the functionality comes from packages that are developed by the open source community. The most important packages for data science are: NumPy, SciPy, Pandas, and Matplotlib.  We will introduce each of these packages as we go through the training materials as they are used heavily in `OG-Core` and the corresponding country calibration packages.
 
-There are several ways to interact with Python: (1) through a [Jupyter Notebook](https://jupyter.org/), (2) interactively through an iPython session, (3) by running a Python script from the command line, or (4) by running a Python script from an IDE such as [Spyder](https://www.spyder-ide.org/).
+
+## Installing Python
+We recommend that you download the Anaconda distribution of Python provided by [Anaconda](https://www.anaconda.com/download). We also recommend the most recent stable version of Python, which is currently Python 3.11. This can be done from the [Anaconda download page](https://www.anaconda.com/download) for Windows, Mac OSX, and Linux machines. The code we will be writing uses common Python libraries such as `NumPy`, `SciPy`, `pickle`, `os`, `matplotlib`, and `time`, which are all included in the Anaconda distribution. If you are using a different distribution of Python, you may need to install these packages separately.
+
+
+## Working with Python
+
+There are several ways to interact with Python:
+1. [Jupyter Notebook](https://jupyter.org/)
+2. iPython session
+3. Running a Python script from the command line
+4. Running a Python script from an IDE such as [Spyder](https://www.spyder-ide.org/).
 
 In our recommended Python development workflow, you will write Python scripts and modules (`*.py` files) in a text editor. Then you will run those scripts from your terminal. You will want a capable text editor for developing your code. Many capable text editors exist, but we recommend [Visual Studio Code](https://code.visualstudio.com) (VS Code). As you learn Python and complete the exercises in this training program, you will also use Python interactively in a Jupyter Notebook or iPython session. VS Code will be helpful here as well as it will allow you open Jupyter Notebooks and run Python interactively through the text editor.
 
-VS Code is free and will be included with your installation of Anaconda.  This is a very capable text editor and will include syntax highlighting for Python and and built in Git controls.  In addition to the basics, you may want to use a more advanced linter for Python.  This will help you correct syntax errors on the fly and provide helpful information as you declare objects and call functions.  [This link](https://code.visualstudio.com/docs/python/linting) provides step-by-step instructions on using more advanced linting in VS Code.
+VS Code is free and will be included with your installation of Anaconda. This is a very capable text editor and will include syntax highlighting for Python and and built in Git controls. In addition to the basics, you may want to use a more advanced linter for Python. This will help you correct syntax errors on the fly and provide helpful information as you declare objects and call functions. [This link](https://code.visualstudio.com/docs/python/linting) provides step-by-step instructions on using more advanced linting in VS Code.
 
 Some extensions that we recommend installing into your VS Code:
 * cornflakes-linter
@@ -33,7 +41,15 @@ Some extensions that we recommend installing into your VS Code:
 
 In addition, [GitHub Copilot](https://github.com/features/copilot) is an amazing resource and can be added as an extension to VS Code. However, this service is not free of charge and does require an internet connection to work.
 
-# Python Packages
+```{exercise-start}
+:label: ExerPythonIntro
+```
+Read the BYU ACME "[Introduction to Python](https://acme.byu.edu/00000181-448a-d778-a18f-dfcae22f0001/intro-to-python)" lab and complete Problems 1 through 8 in the lab. {cite}`BYUACME_PythonIntro`
+```{exercise-end}
+```
+
+
+## Python Packages
 
 When using `OG-Core` there are a handful of Python packages that will be useful and that these training materials will cover:
 
@@ -45,8 +61,10 @@ When using `OG-Core` there are a handful of Python packages that will be useful 
 
 All of these will be included as part of your installation of Anaconda.  Anaconda also includes a package manager called `conda` that will allow you to install additional packages and well help keep versions of packages consistent with each other.  We will not cover this in these training materials, but you can find more information about `conda` [here](https://docs.conda.io/en/latest/) and you'll find references to `conda` as we install the `OG-Core` package in the latter part of these training materials.
 
-# Python Training Topics
 
+## Python Training Topics
+
+1. [Python data types]
 1. [Python Standard Library](StandardLibrary.md)
 2. [Object Oriented Programming](OOP.md)
 3. [NumPy](NumPy.md)

--- a/docs/book/python/intro.md
+++ b/docs/book/python/intro.md
@@ -5,6 +5,8 @@ The `OG-Core` model, as well as the country-specific calibration packages, are w
 
 As we walk you through the basics of Python, we will leverage some excellent open source materials put together by [QuantEcon](https://quantecon.org/) and the [Applied and Computational Mathematics Emphasis at BYU (BYU ACME)](https://acme.byu.edu/). And while we will point you to their tutorials, we have customized all our excercises to be relevant to the `OG-Core` model and the calibration packages.
 
+
+(SecPythonIntroOverview)=
 ## Overview of Python
 The Python.org site has documentation essays, one of which is entitled "[What is Python? Executive Summary](https://www.python.org/doc/essays/blurb/)". The first paragraph contains the following description.
 
@@ -15,10 +17,12 @@ In addition to the description above, Python is an open source programming langu
 Python has some built in functionality with the standard library, but most of the functionality comes from packages that are developed by the open source community. The most important packages for data science are: NumPy, SciPy, Pandas, and Matplotlib.  We will introduce each of these packages as we go through the training materials as they are used heavily in `OG-Core` and the corresponding country calibration packages.
 
 
+(SecPythonIntroInstall)=
 ## Installing Python
 We recommend that you download the Anaconda distribution of Python provided by [Anaconda](https://www.anaconda.com/download). We also recommend the most recent stable version of Python, which is currently Python 3.11. This can be done from the [Anaconda download page](https://www.anaconda.com/download) for Windows, Mac OSX, and Linux machines. The code we will be writing uses common Python libraries such as `NumPy`, `SciPy`, `pickle`, `os`, `matplotlib`, and `time`, which are all included in the Anaconda distribution. If you are using a different distribution of Python, you may need to install these packages separately.
 
 
+(SecPythonIntroWorkingWith)=
 ## Working with Python
 
 There are several ways to interact with Python:
@@ -48,7 +52,10 @@ Read the BYU ACME "[Introduction to Python](https://acme.byu.edu/00000181-448a-d
 ```{exercise-end}
 ```
 
+[Put a review of Python data types here: string, byte, float, list, set, dict. Discuss mutability versus immutability as well as iterability. Also introduce NumPy arrays and Pandas DataFrames.]
 
+
+(SecPythonIntroPackages)=
 ## Python Packages
 
 When using `OG-Core` there are a handful of Python packages that will be useful and that these training materials will cover:
@@ -62,9 +69,9 @@ When using `OG-Core` there are a handful of Python packages that will be useful 
 All of these will be included as part of your installation of Anaconda.  Anaconda also includes a package manager called `conda` that will allow you to install additional packages and well help keep versions of packages consistent with each other.  We will not cover this in these training materials, but you can find more information about `conda` [here](https://docs.conda.io/en/latest/) and you'll find references to `conda` as we install the `OG-Core` package in the latter part of these training materials.
 
 
+(SecPythonIntroTopics)=
 ## Python Training Topics
 
-1. [Python data types]
 1. [Python Standard Library](StandardLibrary.md)
 2. [Object Oriented Programming](OOP.md)
 3. [NumPy](NumPy.md)
@@ -73,6 +80,7 @@ All of these will be included as part of your installation of Anaconda.  Anacond
 6. [SciPy](SciPy.md)
 7. [Doc strings and comments](DocStrings.md)
 8. [Unit testing in Python](UnitTesting.md)
+
 
 (SecPythonIntroFootnotes)=
 ## Footnotes

--- a/environment.yml
+++ b/environment.yml
@@ -25,3 +25,4 @@ dependencies:
   - ogcore
   - linecheck
   - yaml-changelog
+  - sphinx-exercise

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "bokeh",
         "sphinx",
         "sphinx-argparse",
+        "sphinx-exercise",
         "sphinxcontrib-bibtex>=2.0.0",
         "sphinx-math-dollar",
         "pydata-sphinx-theme",


### PR DESCRIPTION
This PR does the following:
- Updates `python/intro.md` and adds new references in `UN-OG-Training_references.bib`
- Adds a glossary in `glossary.md` and `_toc.yml`
- Adds the `sphinx-exercise` package to `setup.py`, `environment.yml`, and `_config.yml`

@jdebacker. This last addition of the `sphinx-exercise` package is a great way to include exercises in the book. Look at the code in lines 48-53 of [`./docs/book/python/intro.md`](https://raw.githubusercontent.com/OpenRG/UN-OG-Training/main/docs/book/python/intro.md) and see how it is rendered in the Jupyter Book.