### PR TITLE
add iframe examples

### DIFF
--- a/docs/book/python/NumPy.md
+++ b/docs/book/python/NumPy.md
@@ -26,7 +26,7 @@ b=
   \end{bmatrix}
 \].
 $$
-  Use the `shape` method of Numpy arrays to print the shape of this matrix.  Use array slicing to print the first row of `b`, which represents the lifecycle savings decisions of the first agent (i.e., the amount they choose to save in each of their 5 periods of life).  Use array slicing to print the second column of `b`, which is the saves of both agents when they are in their second period of life.  Finally, use array slicing to print the first two rows and the last three columns of `b` (i.e., the savings of both agents from middle age onwards).
+  Use the `shape` method of NumPy arrays to print the shape of this matrix.  Use array slicing to print the first row of `b`, which represents the lifecycle savings decisions of the first agent (i.e., the amount they choose to save in each of their 5 periods of life).  Use array slicing to print the second column of `b`, which is the saves of both agents when they are in their second period of life.  Finally, use array slicing to print the first two rows and the last three columns of `b` (i.e., the savings of both agents from middle age onwards).
 ```{exercise-end}
 ```
 

--- a/docs/book/python/NumPy.md
+++ b/docs/book/python/NumPy.md
@@ -1,7 +1,14 @@
 (Chap_Numpy)=
 # NumPy
 
-ACME materials link...
+<div>
+  <iframe id="inlineFrameExample"
+      title="Inline Frame Example"
+      width="100%"
+      height="700"
+      src="https://acme.byu.edu/00000181-448a-d778-a18f-dfcae22f0001/intro-to-python">
+  </iframe>
+</div>
 
 
 # Exercises

--- a/docs/book/python/intro.md
+++ b/docs/book/python/intro.md
@@ -45,6 +45,16 @@ Some extensions that we recommend installing into your VS Code:
 
 In addition, [GitHub Copilot](https://github.com/features/copilot) is an amazing resource and can be added as an extension to VS Code. However, this service is not free of charge and does require an internet connection to work.
 
+
+<div>
+  <iframe id="inlineFrameExample"
+      title="Inline Frame Example"
+      width="100%"
+      height="700"
+      src="https://acme.byu.edu/00000181-448a-d778-a18f-dfcae22f0001/intro-to-python">
+  </iframe>
+</div>
+
 ```{exercise-start}
 :label: ExerPythonIntro
 ```


### PR DESCRIPTION
This PR adds examples for the use of iframes to embed pdfs to the Python intro and Numpy chapters.

To me, this is a nice solution to embed the ACME materials directly from their website (so long as we use the older version with each chapter as it's own PDF). 

Here's what this would look like:

<img width="1325" alt="Screenshot 2023-10-01 at 9 45 54 PM" src="https://github.com/OpenRG/UN-OG-Training/assets/10715924/369a6bfd-86f2-4845-a66f-a655d0504f5b">


cc @rickecon 