### PR TITLE
Updates args when calling `glue`

### DIFF
--- a/docs/book/OG/Output.md
+++ b/docs/book/OG/Output.md
@@ -139,7 +139,7 @@ for key in path_dict.keys():
         output_dict[key].append(pickle.load(BytesIO(r.content)))
 # make table
 table = ot.macro_table(output_dict["TPI"][0], output_dict["Params"][0], output_dict["TPI"][1], output_dict["Params"][1], output_type="pct_diff", num_years=10, start_year= output_dict["Params"][0].start_year)
-glue(table.to_markdown())
+glue('pct_change_table', table.to_markdown())
 ```
 
 
@@ -186,7 +186,7 @@ for key in path_dict.keys():
         output_dict[key].append(pickle.loads(BytesIO(r.content).getvalue()))
 # make table
 fig = op.plot_aggregates(output_dict["TPI"][0], output_dict["Params"][0], output_dict["TPI"][1], output_dict["Params"][1], plot_type="pct_diff", start_year= output_dict["Params"][0].start_year)
-glue(fig.show())
+glue("pct_change_agg_fig", fig, display=False)
 ```
 
 ```{figure} ../images/OG/Output/MacroAgg_PctChange.png


### PR DESCRIPTION
This PR updates the caller to the `glue` function in the `myst-nb` package.  The more recent version of `myst-nb` call for a label then the variable to be glued.

May address Issue #48 
